### PR TITLE
Edit File and Streaming Uploads

### DIFF
--- a/pymogile/client.py
+++ b/pymogile/client.py
@@ -8,7 +8,7 @@ This module is a client library for the MogileFS distributed file system
 """
 from pymogile.backend import Backend
 from pymogile.exceptions import MogileFSError
-from pymogile.file import NormalHTTPFile, LargeHTTPFile
+from pymogile.file import NormalHTTPFile, LargeHTTPFile, StreamingHTTPFile
 from urlparse import urlparse
 import httplib
 
@@ -45,7 +45,8 @@ class Client(object):
     return self.backend.last_host_connected
 
   def new_file(self, key, cls=None, largefile=False, content_length=0,
-               create_open_arg=None, create_close_arg=None, opts=None):
+               create_open_arg=None, create_close_arg=None, opts=None,
+               streaming=False):
     """
     Start creating a new filehandle with the given key,
     and option given class and options.
@@ -92,6 +93,8 @@ class Client(object):
     # TODO
     if largefile:
       file_class = LargeHTTPFile
+    elif streaming:
+      file_class = StreamingHTTPFile
     else:
       file_class = NormalHTTPFile
 

--- a/pymogile/file.py
+++ b/pymogile/file.py
@@ -128,6 +128,7 @@ class LargeHTTPFile(HTTPFile):
                key=None, 
                readonly=False, 
                create_close_arg=None, 
+               mutate_file=False,
                **kwds):
 
     super(LargeHTTPFile, self).__init__(mg, fid, key, cls, create_close_arg)
@@ -162,6 +163,8 @@ class LargeHTTPFile(HTTPFile):
     self._is_closed = 0
     self._pos = 0
     self._eof = 0
+
+    self.mutate_file = mutate_file
 
   def read(self, n= -1):
     if self._is_closed:
@@ -228,7 +231,7 @@ class LargeHTTPFile(HTTPFile):
                    'fid': self.fid,
                    'devid': self.devid,
                    'domain': self.mg.domain,
-                   'size': self.length,
+                   'size': self.mutate_file and -1 or self.length,
                    'key': self.key,
                    'path': self.path,
                  }

--- a/pymogile/file.py
+++ b/pymogile/file.py
@@ -99,6 +99,10 @@ class HTTPFile(object):
 
     conn = connection(url.netloc)
     target = urlparse.urlunsplit((None, None, url.path, url.query, url.fragment))
+    if kwds.get('stream'):
+      conn.connect()
+      conn.putrequest(method, url.path)
+      return conn
     conn.request(method, target, *args, **kwds)
     res = conn.getresponse(buffering=True)
     if is_success(res):
@@ -334,3 +338,72 @@ class NormalHTTPFile(HTTPFile):
 
   def tell(self):
     return self._fp.tell()
+
+class StreamingHTTPFile(HTTPFile):
+  def __init__(self,
+               path,
+               devid,
+               backup_dests=None,
+               mg=None,
+               fid=None,
+               cls=None,
+               key=None,
+               create_close_arg=None,
+               content_length=0,
+               **kwds):
+
+    super(StreamingHTTPFile, self).__init__(mg, fid, key, cls, create_close_arg)
+
+    if backup_dests is None:
+      backup_dests = []
+    self._paths = [(devid, path)] + list(backup_dests)
+    self._is_closed = 0
+
+    self.size = content_length
+
+    for tried_devid, tried_path in self._paths:
+      try:
+        try:
+          created = self._makedirs(tried_path)
+        except:
+          pass
+        self.conn = self._request(tried_path, "PUT", stream=True)
+        self.conn.putheader('Content-Length', self.size)
+        self.conn.endheaders()
+        self.devid = tried_devid
+        self.path = tried_path
+        break
+      except HTTPError, e:
+        continue
+    else:
+      raise NotImplementedError()
+
+  def paths(self):
+    return self._paths
+
+  def write(self, content):
+    self.conn.send(content)
+
+  def close(self):
+    if not self._is_closed:
+      self._is_closed = True
+
+      res = self.conn.getresponse()
+      if not is_success(res):
+        raise HTTPError(res.status, res.reason)
+
+      params = {
+                 'fid'   : self.fid,
+                 'domain': self.mg.domain,
+                 'key'   : self.key,
+                 'path'  : self.path,
+                 'devid' : self.devid,
+                 'size'  : self.size
+               }
+      if self.create_close_arg:
+        params.update(self.create_close_arg)
+      try:
+        self.mg.backend.do_request('create_close', params)
+      except MogileFSError, e:
+        if e.err != 'empty_file':
+          raise

--- a/pymogile/file.py
+++ b/pymogile/file.py
@@ -14,7 +14,7 @@ def is_success(response):
 
 def get_content_length(response):
   try:
-    return long(response.getheaders('content-length'))
+    return long(response.getheader('content-length'))
   except (TypeError, ValueError):
     return 0
 
@@ -128,7 +128,6 @@ class LargeHTTPFile(HTTPFile):
                key=None, 
                readonly=False, 
                create_close_arg=None, 
-               mutate_file=False,
                **kwds):
 
     super(LargeHTTPFile, self).__init__(mg, fid, key, cls, create_close_arg)
@@ -163,8 +162,6 @@ class LargeHTTPFile(HTTPFile):
     self._is_closed = 0
     self._pos = 0
     self._eof = 0
-
-    self.mutate_file = mutate_file
 
   def read(self, n= -1):
     if self._is_closed:
@@ -231,7 +228,7 @@ class LargeHTTPFile(HTTPFile):
                    'fid': self.fid,
                    'devid': self.devid,
                    'domain': self.mg.domain,
-                   'size': self.mutate_file and -1 or self.length,
+                   'size': self.length,
                    'key': self.key,
                    'path': self.path,
                  }

--- a/pymogile/file.py
+++ b/pymogile/file.py
@@ -100,7 +100,7 @@ class HTTPFile(object):
     conn = connection(url.netloc)
     target = urlparse.urlunsplit((None, None, url.path, url.query, url.fragment))
     conn.request(method, target, *args, **kwds)
-    res = conn.getresponse()
+    res = conn.getresponse(buffering=True)
     if is_success(res):
       return res
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -241,22 +241,22 @@ class TestClient(unittest.TestCase):
       self.assertTrue(paths)
 
 
-#  def test_edit_file(self): 
-#    cl = Client(TEST_NS, HOSTS)
-#    key = 'test_file_%s_%s' % (random.random(), time.time())
-#
-#    cl.store_content(key, "SPAM")
-#    assert cl.get_paths(key)
-#    assert cl.get_file_data(key) == "SPAM"
-#
-#    fp = cl.edit_file(key)
-#    assert fp
-#    fp.write("s")
-#    fp.seek(2)
-#    fp.write("a")
-#    fp.close()
-#
-#    assert cl.get_file_data(key) == "sPaM"
+  def test_edit_file(self):
+    cl = Client(TEST_NS, HOSTS)
+    key = 'test_file_%s_%s' % (random.random(), time.time())
+
+    cl.store_content(key, "SPAM")
+    self.assertTrue(cl.get_paths(key))
+    self.assertEqual("SPAM", cl.get_file_data(key))
+
+    fp = cl.edit_file(key)
+    self.assertTrue(fp)
+    fp.write("s")
+    fp.seek(2)
+    fp.write("a")
+    fp.close()
+
+    self.assertEqual("sPaM", cl.get_file_data(key))
   
   def test_file_like_object(self): 
     client = Client(TEST_NS, HOSTS)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -257,6 +257,22 @@ class TestClient(unittest.TestCase):
     fp.close()
 
     self.assertEqual("sPaM", cl.get_file_data(key))
+
+  def test_append_file(self):
+    cl = Client(TEST_NS, HOSTS)
+    key = 'test_file_%s_%s' % (random.random(), time.time())
+
+    cl.store_content(key, "SPAM")
+    self.assertTrue(cl.get_paths(key))
+    self.assertEqual("SPAM", cl.get_file_data(key))
+
+    fp = cl.edit_file(key)
+    self.assertTrue(fp)
+    fp.seek(4)
+    fp.write("HamEggs")
+    fp.close()
+
+    self.assertEqual("SPAMHamEggs", cl.get_file_data(key))
   
   def test_file_like_object(self): 
     client = Client(TEST_NS, HOSTS)


### PR DESCRIPTION
(Submitting here because you appear to be the most active fork of this project).

Following what the Perl API does, the edit_file method is implemented to fetch an existing and new URL from the tracker, DAV MOVE from one to the other and then pass back a mutable file.

Upon closing the file, a length of -1 is supplied to avoid having to keep an accurate internal counter in LargeHTTPFile.

I've also added the ability to stream file uploads (rather than buffer locally or make a series of PUT requests). Would you prefer this on a separate branch?